### PR TITLE
add a nextChapter field to the Manga type

### DIFF
--- a/crates/tanoshi/src/catalogue/manga.rs
+++ b/crates/tanoshi/src/catalogue/manga.rs
@@ -234,4 +234,14 @@ impl Manga {
         let db = ctx.data_unchecked::<GlobalContext>().mangadb.clone();
         Ok(db.get_chapter_by_id(id).await?.into())
     }
+
+    async fn next_chapter(
+        &self,
+        ctx: &Context<'_>,
+    ) -> Result<Option<Chapter>> {
+        let db = ctx.data_unchecked::<GlobalContext>().mangadb.clone();
+        let user = user::get_claims(ctx)?;
+
+        Ok(db.get_next_chapter_by_manga_id(user.sub, self.id).await?.map(|c| c.into()))
+    }
 }


### PR DESCRIPTION
I tried Tanoshi and would really like a resume button, so I started this to get the next chapter to read (the first one that’s not read entirely) from the API

note: the `chapter.last_page` of a fully read chapter is `0` (the same as a chapter that was just opened but not scrolled at all). I think this should be the number of the last page instead. what do you think ?

see #187