### PR TITLE
use llvm compiler and dylib engine

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -133,5 +133,5 @@ jobs:
         with:
           command: test
         env:
-          LLVM_SYS_110_PREFIX: ${{ env.LLVM_PATH }}
-          LIBCLANG_PATH: ${{ env.LLVM_PATH }}\bin
+          LLVM_SYS_110_PREFIX: C:\Program Files\LLVM\bin
+          LIBCLANG_PATH: C:\Program Files\LLVM\bin

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -125,7 +125,7 @@ jobs:
         with:
           command: test
         env:
-          PKG_CONFIG_PATH: /usr/local/opt/icu4c/lib/pkgconfig:/usr/local/opt/libarchive/lib/pkgconfig:/usr/local/opt/zlib/lib/pkgconfig:/usr/local/opt/expat/lib/pkgconfigenv:
+          PKG_CONFIG_PATH: /usr/local/opt/icu4c/lib/pkgconfig:/usr/local/opt/libarchive/lib/pkgconfig:/usr/local/opt/zlib/lib/pkgconfig:/usr/local/opt/expat/lib/pkgconfig
           LLSM_SYS_110_PREFIX: /usr/local/opt/llvm
       - name: Test
         if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -118,7 +118,7 @@ jobs:
         with:
           command: test
         env:
-          LLSM_SYS_110_PREFIX: ${{ env.LLVM_PATH }}
+          LLVM_SYS_110_PREFIX: ${{ env.LLVM_PATH }}
       - name: Test
         if: ${{ matrix.os == 'macos-latest' }}
         uses: actions-rs/cargo@v1
@@ -126,12 +126,12 @@ jobs:
           command: test
         env:
           PKG_CONFIG_PATH: /usr/local/opt/icu4c/lib/pkgconfig:/usr/local/opt/libarchive/lib/pkgconfig:/usr/local/opt/zlib/lib/pkgconfig:/usr/local/opt/expat/lib/pkgconfig
-          LLSM_SYS_110_PREFIX: /usr/local/opt/llvm
+          LLVM_SYS_110_PREFIX: /usr/local/opt/llvm
       - name: Test
         if: ${{ matrix.os == 'windows-latest' }}
         uses: actions-rs/cargo@v1
         with:
           command: test
         env:
-          LLSM_SYS_110_PREFIX: ${{ env.LLVM_PATH }}
+          LLVM_SYS_110_PREFIX: ${{ env.LLVM_PATH }}
           LIBCLANG_PATH: ${{ env.LLVM_PATH }}\bin

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -117,7 +117,7 @@ jobs:
         with:
           command: test
         env:
-          LLSM_SYS_110_PREFIX: ${{ env.LLVM_PATH }
+          LLSM_SYS_110_PREFIX: ${{ env.LLVM_PATH }}
       - name: Test
         if: ${{ matrix.os == 'macos-latest' }}
         uses: actions-rs/cargo@v1

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -94,10 +94,9 @@ jobs:
         if: ${{ matrix.os == 'macos-latest' }}
         run: brew install icu4c libarchive bzip2 lz4 zlib expat
       - name: Install LLVM and Clang
-        if: ${{ matrix.os == 'windows-latest' }}
         uses: KyleMayes/install-llvm-action@v1
         with:
-          version: "11.1"
+          version: "11.0"
       - name: Cache vcpkg
         uses: actions/cache@v2
         if: ${{ matrix.os == 'windows-latest' }}
@@ -117,6 +116,8 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+        env:
+          LLSM_SYS_110_PREFIX: ${{ env.LLVM_PATH }
       - name: Test
         if: ${{ matrix.os == 'macos-latest' }}
         uses: actions-rs/cargo@v1
@@ -124,6 +125,7 @@ jobs:
           command: test
         env:
           PKG_CONFIG_PATH: /usr/local/opt/icu4c/lib/pkgconfig:/usr/local/opt/libarchive/lib/pkgconfig:/usr/local/opt/zlib/lib/pkgconfig:/usr/local/opt/expat/lib/pkgconfig
+          LLSM_SYS_110_PREFIX: ${{ env.LLVM_PATH }}
       - name: Test
         if: ${{ matrix.os == 'windows-latest' }}
         uses: actions-rs/cargo@v1
@@ -131,3 +133,4 @@ jobs:
           command: test
         env:
           LIBCLANG_PATH: C:\Program Files\LLVM\bin
+          LLSM_SYS_110_PREFIX: ${{ env.LLVM_PATH }

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -92,11 +92,12 @@ jobs:
         run: sudo apt update && sudo apt upgrade -y && sudo apt install -y libssl-dev libarchive-dev build-essential cmake llvm clang libicu-dev nettle-dev libacl1-dev liblzma-dev libzstd-dev liblz4-dev libbz2-dev zlib1g-dev libxml2-dev
       - name: Install deps
         if: ${{ matrix.os == 'macos-latest' }}
-        run: brew install icu4c libarchive bzip2 lz4 zlib expat
+        run: brew install icu4c libarchive bzip2 lz4 zlib expat llvm
       - name: Install LLVM and Clang
+        if: ${{ matrix.os != 'macos-latest' }}
         uses: KyleMayes/install-llvm-action@v1
         with:
-          version: "11.0"
+          version: "11.1"
       - name: Cache vcpkg
         uses: actions/cache@v2
         if: ${{ matrix.os == 'windows-latest' }}
@@ -124,13 +125,13 @@ jobs:
         with:
           command: test
         env:
-          PKG_CONFIG_PATH: /usr/local/opt/icu4c/lib/pkgconfig:/usr/local/opt/libarchive/lib/pkgconfig:/usr/local/opt/zlib/lib/pkgconfig:/usr/local/opt/expat/lib/pkgconfig
-          LLSM_SYS_110_PREFIX: ${{ env.LLVM_PATH }}
+          PKG_CONFIG_PATH: /usr/local/opt/icu4c/lib/pkgconfig:/usr/local/opt/libarchive/lib/pkgconfig:/usr/local/opt/zlib/lib/pkgconfig:/usr/local/opt/expat/lib/pkgconfigenv:
+          LLSM_SYS_110_PREFIX: /usr/local/opt/llvm
       - name: Test
         if: ${{ matrix.os == 'windows-latest' }}
         uses: actions-rs/cargo@v1
         with:
           command: test
         env:
-          LIBCLANG_PATH: C:\Program Files\LLVM\bin
           LLSM_SYS_110_PREFIX: ${{ env.LLVM_PATH }}
+          LIBCLANG_PATH: ${{ env.LLVM_PATH }}\bin

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -133,4 +133,4 @@ jobs:
           command: test
         env:
           LIBCLANG_PATH: C:\Program Files\LLVM\bin
-          LLSM_SYS_110_PREFIX: ${{ env.LLVM_PATH }
+          LLSM_SYS_110_PREFIX: ${{ env.LLVM_PATH }}

--- a/crates/tanoshi-cli/Cargo.toml
+++ b/crates/tanoshi-cli/Cargo.toml
@@ -15,7 +15,10 @@ disable-compiler = ["tanoshi-vm/disable-compiler"]
 
 [dependencies]
 tanoshi-lib = { path = "../tanoshi-lib", version = "0.25.1" }
-tanoshi-vm = { path = "../tanoshi-vm", version = "0.4.1" }
+tanoshi-vm = { path = "../tanoshi-vm", version = "0.4.1", default-features = false, features = [
+    "llvm",
+    "dylib",
+] }
 serde_yaml = "0.8"
 tokio = { version = "1", features = ["full"] }
 clap = "3.0.0-beta.4"

--- a/crates/tanoshi-cli/src/main.rs
+++ b/crates/tanoshi-cli/src/main.rs
@@ -56,7 +56,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match opts.subcmd {
         #[cfg(not(feature = "disable-compiler"))]
         SubCommand::Compile => {
-            vm::compile(&extension_path).await?;
+            let triples = [
+                "x86_64-unknown-linux-gnu",
+                "aarch64-unknown-linux-gnu",
+                "x86_64-apple-darwin",
+                "x86_64-pc-windows-msvc",
+            ];
+            for triple in triples {
+                vm::compile_with_target(&extension_path, triple).await?;
+            }
         }
         SubCommand::GenerateJson => {
             generate::generate_json(extension_bus).await?;

--- a/crates/tanoshi-cli/src/main.rs
+++ b/crates/tanoshi-cli/src/main.rs
@@ -57,10 +57,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         #[cfg(not(feature = "disable-compiler"))]
         SubCommand::Compile => {
             let triples = [
-                "x86_64-unknown-linux-gnu",
-                "aarch64-unknown-linux-gnu",
                 "x86_64-apple-darwin",
                 "x86_64-pc-windows-msvc",
+                "x86_64-unknown-linux-gnu",
+                "aarch64-unknown-linux-gnu",
             ];
             for triple in triples {
                 vm::compile_with_target(&extension_path, triple).await?;

--- a/crates/tanoshi-cli/src/main.rs
+++ b/crates/tanoshi-cli/src/main.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(feature = "disable-compiler")]
     vm::load(&extension_path, extension_tx.clone()).await?;
 
-    let extension_bus = ExtensionBus::new("target/wasm32-wasi/release".to_string(), extension_tx);
+    let extension_bus = ExtensionBus::new(extension_path, extension_tx);
 
     match opts.subcmd {
         #[cfg(not(feature = "disable-compiler"))]

--- a/crates/tanoshi-cli/src/main.rs
+++ b/crates/tanoshi-cli/src/main.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(feature = "disable-compiler")]
     vm::load(&extension_path, extension_tx.clone()).await?;
 
-    let extension_bus = ExtensionBus::new(extension_path, extension_tx);
+    let extension_bus = ExtensionBus::new(extension_path.clone(), extension_tx);
 
     match opts.subcmd {
         #[cfg(not(feature = "disable-compiler"))]

--- a/crates/tanoshi-vm/build.rs
+++ b/crates/tanoshi-vm/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=TARGET={}",
+        std::env::var("TARGET").unwrap()
+    );
+}

--- a/crates/tanoshi-vm/src/bus.rs
+++ b/crates/tanoshi-vm/src/bus.rs
@@ -57,7 +57,8 @@ impl ExtensionBus {
         contents: &Bytes,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let path = self.path.join(name).with_extension("tanoshi");
-        ExtensionProxy::compile(contents, &path)?;
+        // ExtensionProxy::compile(contents, &path)?;
+        tokio::fs::write(&path, contents).await?;
 
         Ok(self.tx.send(Command::Load(
             path.to_str().ok_or("path can't to string")?.to_string(),

--- a/crates/tanoshi-vm/src/vm.rs
+++ b/crates/tanoshi-vm/src/vm.rs
@@ -212,6 +212,11 @@ pub async fn load<P: AsRef<Path>>(
     for entry in std::fs::read_dir(&path)?
         .into_iter()
         .filter_map(Result::ok)
+        .filter(|path| {
+            path.file_name()
+                .to_str()
+                .map_or(false, |name| name.contains(env!("TARGET")))
+        })
         .filter(move |path| {
             path.path()
                 .extension()

--- a/crates/tanoshi-vm/src/vm.rs
+++ b/crates/tanoshi-vm/src/vm.rs
@@ -97,7 +97,7 @@ impl ExtensionProxy {
 
         let output = std::path::PathBuf::new()
             .join(&path)
-            .with_extension("tanoshi");
+            .with_extension(format!("{}.tanoshi", target.triple()));
         Self::compile(&wasm_bytes, output, target)?;
 
         // std::fs::remove_file(path)?;

--- a/crates/tanoshi/Cargo.toml
+++ b/crates/tanoshi/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT"
 [dependencies]
 tanoshi-lib = { path = "../tanoshi-lib" }
 tanoshi-vm = { path = "../tanoshi-vm", default-features = false, features = [
-    "llvm",
     "dylib",
     "disable-compiler",
 ] }

--- a/crates/tanoshi/Cargo.toml
+++ b/crates/tanoshi/Cargo.toml
@@ -11,7 +11,8 @@ license = "MIT"
 tanoshi-lib = { path = "../tanoshi-lib" }
 tanoshi-vm = { path = "../tanoshi-vm", default-features = false, features = [
     "llvm",
-    "universal",
+    "dylib",
+    "disable-compiler",
 ] }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1.5"

--- a/crates/tanoshi/Cargo.toml
+++ b/crates/tanoshi/Cargo.toml
@@ -9,7 +9,10 @@ license = "MIT"
 
 [dependencies]
 tanoshi-lib = { path = "../tanoshi-lib" }
-tanoshi-vm = { path = "../tanoshi-vm" }
+tanoshi-vm = { path = "../tanoshi-vm", default-features = false, features = [
+    "llvm",
+    "universal",
+] }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1.5"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
llvm allows for near native speed while dylib allows for native startup sip, this with lower memory consumption. the downside is module compilation take longer and to be precompiled from repo, but because of that we can ship tanoshi without compiler for smaller binary