### PR TITLE
Avoid host-side build requirements for docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,15 @@ RUN cargo chef prepare  --recipe-path recipe.json
 FROM faldez/tanoshi-builder:latest AS builder
 
 COPY --from=planner /app/recipe.json recipe.json
+RUN cargo install trunk wasm-bindgen-cli
+RUN rustup target add wasm32-unknown-unknown
 RUN cargo chef cook --release --recipe-path recipe.json
 
 COPY crates/ /app/crates/
 COPY Cargo.lock /app/Cargo.lock
 COPY Cargo.toml /app/Cargo.toml
+
+RUN cd crates/tanoshi-web; trunk build
 
 RUN cargo build -p tanoshi --release
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,17 @@ RUN cargo chef prepare  --recipe-path recipe.json
 FROM faldez/tanoshi-builder:latest AS builder
 
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo install trunk wasm-bindgen-cli
-RUN rustup target add wasm32-unknown-unknown
+ARG BUILD_WEB
+ENV BUILD_WEB=${BUILD_WEB:-true}
+RUN if [ x${BUILD_WEB} = x"true" ]; then echo $BUILD_WEB; cargo install trunk wasm-bindgen-cli; fi
+RUN if [ x${BUILD_WEB} = x"true" ]; then rustup target add wasm32-unknown-unknown; fi
 RUN cargo chef cook --release --recipe-path recipe.json
 
 COPY crates/ /app/crates/
 COPY Cargo.lock /app/Cargo.lock
 COPY Cargo.toml /app/Cargo.toml
 
-RUN cd crates/tanoshi-web; trunk build
+RUN if [ x${BUILD_WEB} = x"true" ]; then cd crates/tanoshi-web; trunk build; fi
 
 RUN cargo build -p tanoshi --release
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,6 @@ FROM faldez/tanoshi-builder:latest AS builder
 COPY --from=planner /app/recipe.json recipe.json
 ARG BUILD_WEB
 ENV BUILD_WEB=${BUILD_WEB:-true}
-RUN if [ x${BUILD_WEB} = x"true" ]; then echo $BUILD_WEB; cargo install trunk wasm-bindgen-cli; fi
-RUN if [ x${BUILD_WEB} = x"true" ]; then rustup target add wasm32-unknown-unknown; fi
 RUN cargo chef cook --release --recipe-path recipe.json
 
 COPY crates/ /app/crates/


### PR DESCRIPTION
Given that docker supports build containers, it makes no sense to require the host to pre-build `tanoshi-web` when it can be done in the docker container instead. Makes it a 'one button build' with a `docker build .`