### PR TITLE
Fix docker url if not connect redirect to connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Selfhosted web manga reader.
 - MyAnimeList and AniList tracker support
 
 ## Download
-Download from [release page](https://github.com/faldez/tanoshi/releases) or [docker](https://hub.docker.com/repository/docker/faldez/tanoshi).
+Download from [release page](https://github.com/faldez/tanoshi/releases) or [docker](https://hub.docker.com/r/faldez/tanoshi).
 
 ### Desktop
 If you don't plan to host Tanoshi and use from single device you can download desktop version. Download `.msi` for windows, `.deb` or `.AppImage` for linux, `.dmg` for mac.


### PR DESCRIPTION
Try the old docker url https://hub.docker.com/repository/docker/faldez/tanoshi on a private browsing, it will ask to connect instead of showing the page.
Try the new one i propose, it will show you the page without connection at all